### PR TITLE
Add early-stopping option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open('requirements.txt') as f:
 
 REQUIRES = [t.strip() for t in requirements]
 
-opts = dict(name='ss-nmf',
+opts = dict(name='ssnmf',
             maintainer='Valentina Staneva',
             maintainer_email='vms16@uw.edu',
             description='Smooth and Sparse NMF',


### PR DESCRIPTION
This PR adds early-stopping options through an input argument as a dictionary.
The options are:
```
using the objective - 
     early_stopping = {'type': 'cost',
                       'threshold': 0.005,
                       'length_mean': 5,
                       'length_ratio_plateau': 2,
                       'min_iter': 250}
using norm of H curves - 
     early_stopping = {'type': 'h_norm',
                       'threshold': 0.01,
                       'length_mean': 5,
                       'length_ratio_plateau': 1,
                       'min_iter': 250}
default: None, i.e., no early stopping
```